### PR TITLE
Don't write Pandas index to CSV file, don't sort rows

### DIFF
--- a/csvmerge.py
+++ b/csvmerge.py
@@ -43,7 +43,7 @@ def main():
         dat.append(pd.read_csv(os.path.normpath(f.strip()), sep=args.delimiter, encoding=args.encoding))
 
     # combine them by matching columns
-    pd.concat(dat).to_csv(args.output, sep=args.delimiter, encoding=args.encoding)
+    pd.concat(dat, sort=False).to_csv(args.output, sep=args.delimiter, encoding=args.encoding, index=False)
 
     print('Done.')
 


### PR DESCRIPTION
I got a warning with a newer version of pandas that `sort=False` must be added because the default changes in the future.